### PR TITLE
Show listening address and port when starting

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,6 @@ func main() {
 		Handler: mux,
 	}
 
-	log.Print("Starting server...")
+	log.Printf("Starting server listening on %s...", addr)
 	log.Fatal(s.ListenAndServe())
 }


### PR DESCRIPTION
This makes it easier for people to figure out "ah, the thing is running on *that* port!", or to understand "ah, I can't connect to it from outside because it's listening on localhost!" ;-)